### PR TITLE
Add missing python dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ flask
 flask-cors
 boto3
 gunicorn
+python-dotenv
+openai


### PR DESCRIPTION
## Summary
- include `python-dotenv` and `openai` in `requirements.txt`

## Testing
- `python3 -m pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687aa9312254832297f2e3336296623f